### PR TITLE
docs: update stackblitz url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Vue DevTools <sup>Preview</sup>
 </p>
 
 <p align="center">
-<a href="https://stackblitz.com/edit/vitejs-vite-oxbwzk?embed=1&file=vite.config.ts&view=preview"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt=""></a>
+<a href="https://stackblitz.com/edit/vitejs-vite-oxbwzk?file=vite.config.ts&view=preview"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt=""></a>
 </p>
 
 


### PR DESCRIPTION
According to https://github.com/stackblitz/webcontainer-core/issues/1067, the embed view which was used is not supported by all browsers.

My change is removing the embed parameter to open the project in Stackblitz normal mode :)