### PR TITLE
feat: add `panel position` in settings

### DIFF
--- a/src/client/components.d.ts
+++ b/src/client/components.d.ts
@@ -41,6 +41,7 @@ declare module '@vue/runtime-core' {
     VIconButton: typeof import('./ui-kit/VIconButton.vue')['default']
     VIconTitle: typeof import('./ui-kit/VIconTitle.vue')['default']
     VPanelGrids: typeof import('./ui-kit/VPanelGrids.vue')['default']
+    VPanelPosition: typeof import('./ui-kit/VPanelPosition.vue')['default']
     VSectionBlock: typeof import('./ui-kit/VSectionBlock.vue')['default']
     VSelect: typeof import('./ui-kit/VSelect.vue')['default']
     VSwitch: typeof import('./ui-kit/VSwitch.vue')['default']

--- a/src/client/components/DockingPanel.vue
+++ b/src/client/components/DockingPanel.vue
@@ -1,56 +1,14 @@
-<script setup lang="ts">
-import { useDevtoolsClient } from '../logic/client'
-
-const { position: _position } = useFrameState()
-const frameState = ref({
-  position: _position.value,
-})
-
-const client = useDevtoolsClient()
-const dockButton = [
-  {
-    position: 'bottom',
-    icon: 'i-carbon-open-panel-filled-bottom',
-  },
-  {
-    position: 'right',
-    icon: 'i-carbon-open-panel-filled-right',
-  },
-  {
-    position: 'left',
-    icon: 'i-carbon-open-panel-filled-left',
-  },
-  {
-    position: 'top',
-    icon: 'i-carbon-open-panel-filled-top',
-  },
-]
-
-function toggle(position: string) {
-  frameState.value.position = position
-  client.value?.panel?.togglePosition(position)
-  _position.value = position
-}
-</script>
-
 <template>
   <div>
     <div px3 py2 border="b base" flex="~ col gap-1">
-      <div text-sm op50>
-        Dock devtools to
-      </div>
-      <div flex="~ gap-1" text-lg>
-        <button
-          v-for="(item) in dockButton" :key="item.position"
-          :class="[frameState.position === item.position ? 'text-primary' : 'op50', item.icon]"
-          @click="toggle(item.position)"
-        />
-      </div>
+      <div text-sm op50>Dock devtools to</div>
+      <VPanelPosition />
     </div>
     <div px3 py2 border="b base" flex="~ gap-2">
       <VDarkToggle v-slot="{ toggle, isDark }">
         <VButton n="sm primary" @click="toggle()">
-          <div carbon-sun translate-y--1px dark:carbon-moon /> {{ isDark.value ? 'Dark' : 'Light' }}
+          <div carbon-sun dark:carbon-moon translate-y--1px />
+          {{ isDark.value ? "Dark" : "Light" }}
         </VButton>
       </VDarkToggle>
       <RouterLink
@@ -58,7 +16,8 @@ function toggle(position: string) {
         class="n-button-base active:n-button-active focus-visible:n-focus-base n-transition n-primary n-sm hover:n-button-hover n-disabled:n-disabled"
         to="/settings"
       >
-        <div carbon-settings translate-y--1px /> Settings
+        <div carbon-settings translate-y--1px />
+        Settings
       </RouterLink>
     </div>
   </div>

--- a/src/client/pages/settings.vue
+++ b/src/client/pages/settings.vue
@@ -73,12 +73,20 @@ function toggleTabCategory(name: string, v: boolean) {
       <div>
         <div py3 flex="~ col gap-1" border="b base">
           <h3 mb1 text-lg>
+            Position
+          </h3>
+          <div>
+            <VPanelPosition />
+          </div>
+        </div>
+        <div py3 flex="~ col gap-1" border="b base">
+          <h3 mb1 text-lg>
             Appearance
           </h3>
           <div>
             <VDarkToggle v-slot="{ toggle, isDark }">
               <VButton n="primary" @click="toggle()">
-                <div carbon-sun translate-y--1px dark:carbon-moon /> {{ isDark.value ? 'Dark' : 'Light' }}
+                <div carbon-sun dark:carbon-moon translate-y--1px /> {{ isDark.value ? 'Dark' : 'Light' }}
               </VButton>
             </VDarkToggle>
           </div>

--- a/src/client/ui-kit/VPanelPosition.vue
+++ b/src/client/ui-kit/VPanelPosition.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { useDevtoolsClient } from '../logic/client'
+
+const { position: _position } = useFrameState()
+
+const frameState = computed(() => ({ position: _position.value }))
+
+const client = useDevtoolsClient()
+
+const dockButton = [
+  {
+    position: 'bottom',
+    icon: 'i-carbon-open-panel-filled-bottom',
+  },
+  {
+    position: 'right',
+    icon: 'i-carbon-open-panel-filled-right',
+  },
+  {
+    position: 'left',
+    icon: 'i-carbon-open-panel-filled-left',
+  },
+  {
+    position: 'top',
+    icon: 'i-carbon-open-panel-filled-top',
+  },
+]
+
+function toggle(position: string) {
+  client.value?.panel?.togglePosition(position)
+  _position.value = position
+}
+</script>
+
+<template>
+  <div flex="~ gap-1" text-lg>
+    <button
+      v-for="item in dockButton"
+      :key="item.position"
+      :class="[frameState.position === item.position ? 'text-primary' : 'op50', item.icon]"
+      @click="toggle(item.position)"
+    />
+  </div>
+</template>


### PR DESCRIPTION
add `panel position` in settings,  Clicking on the vue logo is sometimes not intuitive, Now, like `Appearance`, it is synchronized in Settings