### PR TITLE
feat: add tips for unable to embed website

### DIFF
--- a/src/client/components/DocDetails.vue
+++ b/src/client/components/DocDetails.vue
@@ -14,8 +14,14 @@ function navigate(path: string) {
 </script>
 
 <template>
-  <VCard flex="~ gap2" max-h="50vh" cursor-pointer p4 :hover="data.id === 'vue' ? '' : 'border-primary'"
-    @click="emit('navigate', data)">
+  <VCard
+    flex="~ gap2"
+    max-h="50vh"
+    cursor-pointer
+    p4
+    hover="border-primary"
+    @click="emit('navigate', data)"
+  >
     <div flex="~ col gap2" flex-auto of-hidden px1>
       <div of-hidden text-ellipsis ws-nowrap text-lg>
         <span>
@@ -27,20 +33,39 @@ function navigate(path: string) {
         {{ data.description }}
       </div>
 
+      <div v-if="data.hint" op50 flex="~ gap-2">
+        <span i-carbon:warning-filled text-lg />
+        {{ data.hint }}
+      </div>
+
       <div flex-auto />
 
       <div v-if="data.website" flex="~ gap-2" title="Documentation">
         <span i-carbon-link text-lg op50 />
-        <span of-hidden truncate ws-nowrap text-sm op50 hover="op100 underline text-primary"
-          @click.self.stop="navigate(data.website)">
-          {{ data.website.replace(/^https?:\/\//, '') }}
+        <span
+          of-hidden
+          truncate
+          ws-nowrap
+          text-sm
+          op50
+          hover="op100 underline text-primary"
+          @click.self.stop="navigate(data.website)"
+        >
+          {{ data.website.replace(/^https?:\/\//, "") }}
         </span>
       </div>
       <div v-if="data.github" flex="~ gap-2">
         <span i-carbon-logo-github text-lg op50 />
-        <span of-hidden truncate ws-nowrap text-sm op50 hover="op100 underline text-primary"
-          @click.self.stop="navigate(data.github)">
-          {{ data.github.replace(/^https?:\/\/github.com\//, '') }}
+        <span
+          of-hidden
+          truncate
+          ws-nowrap
+          text-sm
+          op50
+          hover="op100 underline text-primary"
+          @click.self.stop="navigate(data.github)"
+        >
+          {{ data.github.replace(/^https?:\/\/github.com\//, "") }}
         </span>
       </div>
 

--- a/src/client/components/DocDetails.vue
+++ b/src/client/components/DocDetails.vue
@@ -14,18 +14,19 @@ function navigate(path: string) {
 </script>
 
 <template>
-  <VCard
-    flex="~ gap2"
-    max-h="50vh"
-    cursor-pointer
-    p4
-    hover="border-primary"
-    @click="emit('navigate', data)"
-  >
+  <VCard flex="~ gap2" max-h="50vh" cursor-pointer p4 hover="border-primary" @click="emit('navigate', data)">
     <div flex="~ col gap2" flex-auto of-hidden px1>
       <div of-hidden text-ellipsis ws-nowrap text-lg>
-        <span>
+        <span flex items-center>
           {{ data.name }}
+          <VTooltip v-if="data.tips" placement="bottom-start">
+            <span i-carbon:warning-filled ml-2 text-3 op-60 />
+            <template #popper>
+              <p>
+                {{ data.tips }}
+              </p>
+            </template>
+          </VTooltip>
         </span>
       </div>
 
@@ -33,22 +34,12 @@ function navigate(path: string) {
         {{ data.description }}
       </div>
 
-      <div v-if="data.hint" op50 flex="~ gap-2">
-        <span i-carbon:warning-filled text-lg />
-        {{ data.hint }}
-      </div>
-
       <div flex-auto />
 
       <div v-if="data.website" flex="~ gap-2" title="Documentation">
         <span i-carbon-link text-lg op50 />
         <span
-          of-hidden
-          truncate
-          ws-nowrap
-          text-sm
-          op50
-          hover="op100 underline text-primary"
+          of-hidden truncate ws-nowrap text-sm op50 hover="op100 underline text-primary"
           @click.self.stop="navigate(data.website)"
         >
           {{ data.website.replace(/^https?:\/\//, "") }}
@@ -57,12 +48,7 @@ function navigate(path: string) {
       <div v-if="data.github" flex="~ gap-2">
         <span i-carbon-logo-github text-lg op50 />
         <span
-          of-hidden
-          truncate
-          ws-nowrap
-          text-sm
-          op50
-          hover="op100 underline text-primary"
+          of-hidden truncate ws-nowrap text-sm op50 hover="op100 underline text-primary"
           @click.self.stop="navigate(data.github)"
         >
           {{ data.github.replace(/^https?:\/\/github.com\//, "") }}

--- a/src/client/logic/documentations.ts
+++ b/src/client/logic/documentations.ts
@@ -11,7 +11,7 @@ export const data = [
     github: 'https://github.com/vuejs/core',
     icon: VueIcon,
     deny: true,
-    hint: 'Because of the cn.vuejs.org security setting, this will be opened from the new TAB',
+    hint: 'Because of the vuejs.org security setting, this will be opened from the new TAB',
   },
   {
     id: 'vue-router',

--- a/src/client/logic/documentations.ts
+++ b/src/client/logic/documentations.ts
@@ -10,6 +10,8 @@ export const data = [
     website: 'https://vuejs.org',
     github: 'https://github.com/vuejs/core',
     icon: VueIcon,
+    deny: true,
+    hint: 'Because of the cn.vuejs.org security setting, this will be opened from the new TAB',
   },
   {
     id: 'vue-router',

--- a/src/client/logic/documentations.ts
+++ b/src/client/logic/documentations.ts
@@ -10,8 +10,8 @@ export const data = [
     website: 'https://vuejs.org',
     github: 'https://github.com/vuejs/core',
     icon: VueIcon,
-    deny: true,
-    hint: 'Because of the vuejs.org security setting, this will be opened from the new TAB',
+    openInBlank: true,
+    tips: 'Unable to embed it due to the security settings',
   },
   {
     id: 'vue-router',

--- a/src/client/pages/documentations.vue
+++ b/src/client/pages/documentations.vue
@@ -11,10 +11,10 @@ rpc.getPackages().then((res) => {
 })
 
 function navigate(data: DocumentInfo) {
-  // vue website is not allowed to be embedded?
-  if (data.id === 'vue')
-    return
-  iframeViewUrl.value = data.website
+  if (data.deny)
+    window.open(data.website, '_blank')
+  else
+    iframeViewUrl.value = data.website
 }
 
 function back() {
@@ -26,8 +26,23 @@ function back() {
   <div v-if="iframeViewUrl" relative h-screen>
     <IframeView :src="iframeViewUrl" />
     <teleport to="body">
-      <span fixed left-2 top-2 z-1000 h-8 w-8 flex cursor-pointer select-none items-center justify-center rounded-5
-        bg-base hover="text-primary" @click.prevent.stop="back">
+      <span
+        fixed
+        left-2
+        top-2
+        z-1000
+        h-8
+        w-8
+        flex
+        cursor-pointer
+        select-none
+        items-center
+        justify-center
+        rounded-5
+        bg-base
+        hover="text-primary"
+        @click.prevent.stop="back"
+      >
         <i tabler:arrow-back-up />
       </span>
     </teleport>

--- a/src/client/pages/documentations.vue
+++ b/src/client/pages/documentations.vue
@@ -11,7 +11,7 @@ rpc.getPackages().then((res) => {
 })
 
 function navigate(data: DocumentInfo) {
-  if (data.deny)
+  if (data.openInBlank)
     window.open(data.website, '_blank')
   else
     iframeViewUrl.value = data.website
@@ -27,21 +27,8 @@ function back() {
     <IframeView :src="iframeViewUrl" />
     <teleport to="body">
       <span
-        fixed
-        left-2
-        top-2
-        z-1000
-        h-8
-        w-8
-        flex
-        cursor-pointer
-        select-none
-        items-center
-        justify-center
-        rounded-5
-        bg-base
-        hover="text-primary"
-        @click.prevent.stop="back"
+        fixed left-2 top-2 z-1000 h-8 w-8 flex cursor-pointer select-none items-center justify-center rounded-5
+        bg-base hover="text-primary" @click.prevent.stop="back"
       >
         <i tabler:arrow-back-up />
       </span>

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,6 @@ export interface DocumentInfo {
   website: string
   github: string
   icon: string
-  hint: string
-  deny: boolean
+  tips: string
+  openInBlank: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,4 +79,6 @@ export interface DocumentInfo {
   website: string
   github: string
   icon: string
+  hint: string
+  deny: boolean
 }


### PR DESCRIPTION
If I hadn’t looked at the source code, I wouldn’t know what caused the vue document in the document tab to fail to open, so for a better experience, I added a reminder and set that the website that cannot be opened in the form of an iframe will be in the form of a tab Open