### PR TITLE
chore: modify the placeholder element location

### DIFF
--- a/src/client/pages/overview.vue
+++ b/src/client/pages/overview.vue
@@ -8,8 +8,6 @@ import { isMacOS } from '../utils'
 <template>
   <VPanelGrids h-screen w-full flex of-auto>
     <div flex="~ col gap2" ma h-full max-w-300 w-full px20>
-      <div flex-auto />
-
       <!-- Banner -->
       <div flex="~ col" mt-20 items-center>
         <div flex="~" mt--10 items-center justify-center>

--- a/src/client/pages/overview.vue
+++ b/src/client/pages/overview.vue
@@ -27,6 +27,7 @@ import { isMacOS } from '../utils'
           <code op40>v{{ version }}</code>
         </div>
       </div>
+      <div flex-auto />
       <!-- Main Grid -->
       <div flex="~ gap2 wrap">
         <div p4 theme-card-green flex="~ col auto">


### PR DESCRIPTION
My guess is that this element is probably used as a placeholder, but so far it's almost 1/3 empty at the top，so I adjusted the lower placeholder position to make it as consistent as possible
before:
![1683991168152](https://github.com/webfansplz/vite-plugin-vue-devtools/assets/20943608/ae3f7007-1613-4d66-adb8-c46c25fbd5d4)

after:
![image](https://github.com/webfansplz/vite-plugin-vue-devtools/assets/20943608/a1eb7841-f5c8-42e4-aeb5-ae0e706ea9d9)
