### PR TITLE
feat: support click outside to close modal

### DIFF
--- a/src/client/composables/state.ts
+++ b/src/client/composables/state.ts
@@ -4,12 +4,14 @@ export interface DevToolsFrameState {
   route: string
   position: string
   isFirstVisit: boolean
+  clickOut: boolean
 }
 
 const frameState = useLocalStorage<DevToolsFrameState>('__vue-devtools-frame-state__', {
   route: '/',
   position: 'bottom',
   isFirstVisit: true,
+  clickOut: false,
 }, { mergeDefaults: true })
 
 const frameStateRefs = toRefs(frameState)

--- a/src/client/composables/state.ts
+++ b/src/client/composables/state.ts
@@ -4,14 +4,14 @@ export interface DevToolsFrameState {
   route: string
   position: string
   isFirstVisit: boolean
-  clickOut: boolean
+  closeOnOutsideClick: boolean
 }
 
 const frameState = useLocalStorage<DevToolsFrameState>('__vue-devtools-frame-state__', {
   route: '/',
   position: 'bottom',
   isFirstVisit: true,
-  clickOut: false,
+  closeOnOutsideClick: false,
 }, { mergeDefaults: true })
 
 const frameStateRefs = toRefs(frameState)

--- a/src/client/pages/settings.vue
+++ b/src/client/pages/settings.vue
@@ -5,6 +5,8 @@ const {
   hiddenTabCategories,
 } = useDevToolsSettings()
 
+const { clickOut } = useFrameState()
+
 const scaleOptions = [
   ['Tiny', 12 / 15],
   ['Small', 14 / 15],
@@ -27,6 +29,10 @@ function toggleTabCategory(name: string, v: boolean) {
     hiddenTabCategories.value = hiddenTabCategories.value.filter(i => i !== name)
   else
     hiddenTabCategories.value.push(name)
+}
+
+function toggleClickOut() {
+  clickOut.value = !clickOut.value
 }
 </script>
 
@@ -92,6 +98,12 @@ function toggleTabCategory(name: string, v: boolean) {
               {{ i[0] }}
             </option>
           </VSelect>
+        </div>
+        <div py3 flex="~ justify-between gap-1">
+          <h3 mb1 text-lg>
+            Click out
+          </h3>
+          <VSwitch flex="~ row-reverse" py1 n-primary :model-value="clickOut" @update:model-value="toggleClickOut" />
         </div>
       </div>
     </div>

--- a/src/client/pages/settings.vue
+++ b/src/client/pages/settings.vue
@@ -5,7 +5,7 @@ const {
   hiddenTabCategories,
 } = useDevToolsSettings()
 
-const { clickOut } = useFrameState()
+const { closeOnOutsideClick } = useFrameState()
 
 const scaleOptions = [
   ['Tiny', 12 / 15],
@@ -32,7 +32,7 @@ function toggleTabCategory(name: string, v: boolean) {
 }
 
 function toggleClickOut() {
-  clickOut.value = !clickOut.value
+  closeOnOutsideClick.value = !closeOnOutsideClick.value
 }
 </script>
 
@@ -45,20 +45,28 @@ function toggleClickOut() {
           Tabs
         </h3>
         <template v-for="[name, tabs] of categories" :key="name">
-          <div v-if="tabs.length" flex="~ col gap-1" mx--1
-            :class="hiddenTabCategories.includes(name) ? 'op50 grayscale' : ''" pt-2>
-            <VSwitch flex="~ row-reverse" px2 py1 n-lime :model-value="!hiddenTabCategories.includes(name)"
-              @update:model-value="v => toggleTabCategory(name, v)">
+          <div
+            v-if="tabs.length" flex="~ col gap-1" mx--1
+            :class="hiddenTabCategories.includes(name) ? 'op50 grayscale' : ''" pt-2
+          >
+            <VSwitch
+              flex="~ row-reverse" px2 py1 n-lime :model-value="!hiddenTabCategories.includes(name)"
+              @update:model-value="v => toggleTabCategory(name, v)"
+            >
               <div flex="~ gap-2" flex-auto items-center justify-start>
                 <span capitalize op75>{{ name }}</span>
               </div>
             </VSwitch>
             <div flex="~ col gap-1" border="~ base rounded" py3 pl4 pr2>
               <template v-for="tab of tabs" :key="tab.name">
-                <VSwitch flex="~ row-reverse" py1 n-primary :model-value="!hiddenTabs.includes(tab.title)"
-                  @update:model-value="v => toggleTab(tab.title, v)">
-                  <div flex="~ gap-2" flex-auto items-center justify-start
-                    :class="hiddenTabs.includes(tab.title) ? 'op25' : ''">
+                <VSwitch
+                  flex="~ row-reverse" py1 n-primary :model-value="!hiddenTabs.includes(tab.title)"
+                  @update:model-value="v => toggleTab(tab.title, v)"
+                >
+                  <div
+                    flex="~ gap-2" flex-auto items-center justify-start
+                    :class="hiddenTabs.includes(tab.title) ? 'op25' : ''"
+                  >
                     <TabIcon text-xl :icon="tab.icon" :title="tab.title" />
                     <span>{{ tab.title }}</span>
                   </div>
@@ -84,7 +92,7 @@ function toggleClickOut() {
           <div>
             <VDarkToggle v-slot="{ toggle, isDark }">
               <VButton n="primary" @click="toggle">
-                <div carbon-sun dark:carbon-moon translate-y--1px /> {{ isDark.value ? 'Dark' : 'Light' }}
+                <div carbon-sun translate-y--1px dark:carbon-moon /> {{ isDark.value ? 'Dark' : 'Light' }}
               </VButton>
             </VDarkToggle>
           </div>
@@ -103,7 +111,7 @@ function toggleClickOut() {
           <h3 mb1 text-lg>
             Click out
           </h3>
-          <VSwitch flex="~ row-reverse" py1 n-primary :model-value="clickOut" @update:model-value="toggleClickOut" />
+          <VSwitch flex="~ row-reverse" py1 n-primary :model-value="closeOnOutsideClick" @update:model-value="toggleClickOut" />
         </div>
       </div>
     </div>

--- a/src/client/pages/settings.vue
+++ b/src/client/pages/settings.vue
@@ -31,7 +31,7 @@ function toggleTabCategory(name: string, v: boolean) {
     hiddenTabCategories.value.push(name)
 }
 
-function toggleClickOut() {
+function toggleClickOutside() {
   closeOnOutsideClick.value = !closeOnOutsideClick.value
 }
 </script>
@@ -109,9 +109,9 @@ function toggleClickOut() {
         </div>
         <div py3 flex="~ justify-between gap-1">
           <h3 mb1 text-lg>
-            Click out
+            Close DevTools when clicking outside
           </h3>
-          <VSwitch flex="~ row-reverse" py1 n-primary :model-value="closeOnOutsideClick" @update:model-value="toggleClickOut" />
+          <VSwitch flex="~ row-reverse" py1 n-primary :model-value="closeOnOutsideClick" @update:model-value="toggleClickOutside" />
         </div>
       </div>
     </div>

--- a/src/node/Container.vue
+++ b/src/node/Container.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
+import { onClickOutside } from '@vueuse/core'
 import vueDevToolsOptions from 'virtual:vue-devtools-options'
 
 // Reuse @vuejs/devtools instance first
@@ -378,10 +379,20 @@ onMounted(() => {
       togglePanel()
   })
 })
+
+const modalRef = ref(null)
+onClickOutside(modalRef, () => {
+  const frameState = localStorage.getItem('__vue-devtools-frame-state__')
+  if (frameState) {
+    const parsedFrameState = JSON.parse(frameState)
+    if (parsedFrameState.clickOut)
+      panelVisible.value = false
+  }
+})
 </script>
 
 <template>
-  <div class="vue-devtools-panel" :style="panelPosition">
+  <div ref="modalRef" class="vue-devtools-panel" :style="panelPosition">
     <!-- client -->
     <iframe ref="iframe" :src="clientUrl" :style="{
       'pointer-events': isDragging ? 'none' : 'auto',

--- a/src/node/Container.vue
+++ b/src/node/Container.vue
@@ -390,7 +390,7 @@ window.addEventListener('click', (event) => {
   const frameState = localStorage.getItem('__vue-devtools-frame-state__')
   if (frameState) {
     const parsedFrameState = JSON.parse(frameState)
-    if (parsedFrameState.clickOut)
+    if (parsedFrameState.closeOnOutsideClick)
       panelVisible.value = false
   }
 })

--- a/src/node/Container.vue
+++ b/src/node/Container.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { onClickOutside } from '@vueuse/core'
+import { onClickOutside, useElementHover } from '@vueuse/core'
 import vueDevToolsOptions from 'virtual:vue-devtools-options'
 
 // Reuse @vuejs/devtools instance first
@@ -380,12 +380,15 @@ onMounted(() => {
   })
 })
 
+const toggleButtonRef = ref(null)
+const isHovered = useElementHover(toggleButtonRef)
+
 const modalRef = ref(null)
 onClickOutside(modalRef, () => {
   const frameState = localStorage.getItem('__vue-devtools-frame-state__')
   if (frameState) {
     const parsedFrameState = JSON.parse(frameState)
-    if (parsedFrameState.clickOut)
+    if (parsedFrameState.clickOut && !isHovered.value)
       panelVisible.value = false
   }
 })
@@ -423,8 +426,10 @@ onClickOutside(modalRef, () => {
     </template>
   </div>
   <!-- toggle button -->
-  <button class="vue-devtools-toggle" aria-label="Toggle devtools panel" :style="toggleButtonPosition"
-    @click.prevent="togglePanel">
+  <button
+    ref="toggleButtonRef" class="vue-devtools-toggle" aria-label="Toggle devtools panel" :style="toggleButtonPosition"
+    @click.prevent="togglePanel"
+  >
     <svg viewBox="0 0 256 198" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path fill="#41B883" d="M204.8 0H256L128 220.8L0 0h97.92L128 51.2L157.44 0h47.36Z" />
       <path fill="#41B883" d="m0 0l128 220.8L256 0h-51.2L128 132.48L50.56 0H0Z" />

--- a/src/node/Container.vue
+++ b/src/node/Container.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { onClickOutside, useElementHover } from '@vueuse/core'
 import vueDevToolsOptions from 'virtual:vue-devtools-options'
 
 // Reuse @vuejs/devtools instance first
@@ -381,14 +380,17 @@ onMounted(() => {
 })
 
 const toggleButtonRef = ref(null)
-const isHovered = useElementHover(toggleButtonRef)
-
 const modalRef = ref(null)
-onClickOutside(modalRef, () => {
+
+window.addEventListener('click', (event) => {
+  const modalEl = modalRef.value
+  const toggleButtonEl = toggleButtonRef.value
+  if (!modalEl || !toggleButtonEl || event.composedPath().includes(modalEl) || event.composedPath().includes(toggleButtonEl))
+    return
   const frameState = localStorage.getItem('__vue-devtools-frame-state__')
   if (frameState) {
     const parsedFrameState = JSON.parse(frameState)
-    if (parsedFrameState.clickOut && !isHovered.value)
+    if (parsedFrameState.clickOut)
       panelVisible.value = false
   }
 })
@@ -397,32 +399,48 @@ onClickOutside(modalRef, () => {
 <template>
   <div ref="modalRef" class="vue-devtools-panel" :style="panelPosition">
     <!-- client -->
-    <iframe ref="iframe" :src="clientUrl" :style="{
-      'pointer-events': isDragging ? 'none' : 'auto',
-    }" @load="onLoad" />
+    <iframe
+      ref="iframe" :src="clientUrl" :style="{
+        'pointer-events': isDragging ? 'none' : 'auto',
+      }" @load="onLoad"
+    />
     <!-- resize -->
     <template v-if="panelState.viewMode === 'default'">
       <template v-if="panelState.position !== 'top'">
         <div :class="resizeHorizontalClassName" :style="{ top: 0 }" @mousedown.prevent="toggleDragging('horizontal')" />
-        <div v-if="panelState.position !== 'left'" :class="resizeCornerClassName"
-          :style="{ top: 0, left: 0, cursor: 'nwse-resize' }" @mousedown.prevent="toggleDragging('both')" />
-        <div v-if="panelState.position !== 'right'" :class="resizeCornerClassName"
-          :style="{ top: 0, right: 0, cursor: 'nesw-resize' }" @mousedown.prevent="toggleDragging('both')" />
+        <div
+          v-if="panelState.position !== 'left'" :class="resizeCornerClassName"
+          :style="{ top: 0, left: 0, cursor: 'nwse-resize' }" @mousedown.prevent="toggleDragging('both')"
+        />
+        <div
+          v-if="panelState.position !== 'right'" :class="resizeCornerClassName"
+          :style="{ top: 0, right: 0, cursor: 'nesw-resize' }" @mousedown.prevent="toggleDragging('both')"
+        />
       </template>
 
       <template v-if="panelState.position !== 'bottom'">
-        <div :class="resizeHorizontalClassName" :style="{ bottom: 0 }"
-          @mousedown.prevent="toggleDragging('horizontal')" />
-        <div v-if="panelState.position !== 'right'" :class="resizeCornerClassName"
-          :style="{ bottom: 0, right: 0, cursor: 'nwse-resize' }" @mousedown.prevent="toggleDragging('both')" />
-        <div v-if="panelState.position !== 'left'" :class="resizeCornerClassName"
-          :style="{ bottom: 0, left: 0, cursor: 'nesw-resize' }" @mousedown.prevent="toggleDragging('both')" />
+        <div
+          :class="resizeHorizontalClassName" :style="{ bottom: 0 }"
+          @mousedown.prevent="toggleDragging('horizontal')"
+        />
+        <div
+          v-if="panelState.position !== 'right'" :class="resizeCornerClassName"
+          :style="{ bottom: 0, right: 0, cursor: 'nwse-resize' }" @mousedown.prevent="toggleDragging('both')"
+        />
+        <div
+          v-if="panelState.position !== 'left'" :class="resizeCornerClassName"
+          :style="{ bottom: 0, left: 0, cursor: 'nesw-resize' }" @mousedown.prevent="toggleDragging('both')"
+        />
       </template>
 
-      <div v-if="panelState.position !== 'left'" :class="resizeVerticalClassName" :style="{ left: 0 }"
-        @mousedown.prevent="toggleDragging('vertical')" />
-      <div v-if="panelState.position !== 'right'" :class="resizeVerticalClassName" :style="{ right: 0 }"
-        @mousedown.prevent="toggleDragging('vertical')" />
+      <div
+        v-if="panelState.position !== 'left'" :class="resizeVerticalClassName" :style="{ left: 0 }"
+        @mousedown.prevent="toggleDragging('vertical')"
+      />
+      <div
+        v-if="panelState.position !== 'right'" :class="resizeVerticalClassName" :style="{ right: 0 }"
+        @mousedown.prevent="toggleDragging('vertical')"
+      />
     </template>
   </div>
   <!-- toggle button -->


### PR DESCRIPTION
On some large-sized screens, it is inconvenient to click the `vue logo` to close the modal each time the webpage is full-screen. In fact, you only want the modal to be there when you are viewing the routing track. Provide a configuration item to decide whether you want to click to close