### PR TITLE
fix(components): show error message when copy failed

### DIFF
--- a/src/client/components/Notification.vue
+++ b/src/client/components/Notification.vue
@@ -2,14 +2,21 @@
 const show = ref(false)
 const icon = ref<string | undefined>()
 const text = ref<string | undefined>()
+const type = ref<'primary' | 'error' | undefined>()
 
-provideNotification((_text, _icon, duration = 1500) => {
-  text.value = _text
-  icon.value = _icon
+provideNotification((opt: {
+  text: string
+  icon?: string
+  type?: 'primary' | 'error'
+  duration?: number
+}) => {
+  text.value = opt.text
+  icon.value = opt.icon
   show.value = true
+  type.value = opt.type
   setTimeout(() => {
     show.value = false
-  }, duration)
+  }, opt.duration || 1500)
 })
 </script>
 
@@ -19,6 +26,18 @@ provideNotification((_text, _icon, duration = 1500) => {
     :class="show ? '' : 'pointer-events-none overflow-hidden'"
   >
     <div
+      v-if="type === 'error'"
+      border="~ base"
+      flex="~ inline gap2"
+      m-3 inline-block items-center rounded px-4 py-1 text-red transition-all duration-300 bg-base
+      :style="show ? {} : { transform: 'translateY(-300%)' }"
+      :class="show ? 'shadow' : 'shadow-none'"
+    >
+      <div v-if="icon" :class="`i-${icon}`" />
+      <div>{{ text }}</div>
+    </div>
+    <div
+      v-else
       border="~ base"
       flex="~ inline gap2"
       m-3 inline-block items-center rounded px-4 py-1 text-primary transition-all duration-300 bg-base

--- a/src/client/components/StateFields.vue
+++ b/src/client/components/StateFields.vue
@@ -14,6 +14,7 @@ withDefaults(
 
 const isExpanded = ref<boolean>(true)
 const copy = useCopy()
+const showNotification = useNotification()
 
 function toggleExpanded() {
   isExpanded.value = !isExpanded.value
@@ -24,6 +25,21 @@ function updateExpandedIdCache(id: string) {
     expandedIdCache.value = expandedIdCache.value.filter((i: string) => i !== id)
   else
     expandedIdCache.value.push(id)
+}
+
+function copyContent (value: Record<string, unknown>) {
+  try {
+    copy(JSON.stringify(value))
+  } catch (e: any) {
+    showNotification(
+      {
+        text: e.message,
+        type: 'error',
+        icon: 'carbon-close-outline',
+        duration: 5000,
+      }
+    )
+  }
 }
 </script>
 
@@ -44,7 +60,7 @@ function updateExpandedIdCache(id: string) {
         flex-none
         :title="`Copy ${data.key} to clipboard`"
         icon="carbon-copy"
-        @click.stop="copy(JSON.stringify(data.value))"
+        @click.stop="copyContent(data.value)"
       />
     </h3>
     <div v-show="isExpanded" pl-3>

--- a/src/client/components/StateFields.vue
+++ b/src/client/components/StateFields.vue
@@ -27,17 +27,18 @@ function updateExpandedIdCache(id: string) {
     expandedIdCache.value.push(id)
 }
 
-function copyContent (value: Record<string, unknown>) {
+function copyContent(value: Record<string, unknown>) {
   try {
     copy(JSON.stringify(value))
-  } catch (e: any) {
+  }
+  catch (e: any) {
     showNotification(
       {
         text: e.message,
         type: 'error',
         icon: 'carbon-close-outline',
         duration: 5000,
-      }
+      },
     )
   }
 }

--- a/src/client/composables/context.ts
+++ b/src/client/composables/context.ts
@@ -14,7 +14,12 @@ export function useSingleton<T>() {
 const [
   provideNotification,
   useNotification,
-] = useSingleton<(text: string, icon?: string, duration?: number) => void>()
+] = useSingleton<(opt: {
+  text: string
+  icon?: string
+  type?: 'primary' | 'error'
+  duration?: number
+}) => void>()
 
 export {
   provideNotification,

--- a/src/client/composables/editor.ts
+++ b/src/client/composables/editor.ts
@@ -4,6 +4,10 @@ export function useCopy() {
 
   return (text: string) => {
     clipboard.copy(text)
-    showNotification('Copied to clipboard', 'i-carbon-checkmark')
+    showNotification({
+      text: 'Copied to clipboard',
+      icon: 'carbon:checkmark',
+      duration: 3000,
+    })
   }
 }

--- a/src/client/pages/components.vue
+++ b/src/client/pages/components.vue
@@ -72,7 +72,7 @@ onMounted(() => {
       </Pane>
       <Pane>
         <div v-if="normalizedComponentState.length" h-screen select-none overflow-scroll p-2 class="no-scrollbar">
-          <StateFields v-for="(item, index) in normalizedComponentState" :id="index" :key="item.value" :data="item" />
+          <StateFields v-for="(item, index) in normalizedComponentState" :id="index" :key="item.key" :data="item" />
         </div>
         <VPanelGrids v-else px5>
           <VCard flex="~ col gap2" min-w-30 items-center p3>

--- a/src/client/uno.config.ts
+++ b/src/client/uno.config.ts
@@ -81,5 +81,7 @@ export default defineConfig({
     'i-teenyicons:npm-outline',
     'i-carbon-document-preliminary',
     'i-mdi:eyedropper',
+    'i-carbon-close-outline',
+    'i-carbon:checkmark',
   ],
 })


### PR DESCRIPTION
`JSON.stringify` will report an error when converting objects with internal circular references. At this time, the correct prompt message should appear.

![image](https://github.com/webfansplz/vite-plugin-vue-devtools/assets/24516654/78b48402-101e-493a-adae-a00fd1b3b1b9)
