### PR TITLE
feat(eyedropper): support copy and rgb color model

### DIFF
--- a/src/client/pages/__eyedropper.vue
+++ b/src/client/pages/__eyedropper.vue
@@ -83,7 +83,7 @@ function ErrorBoundary() {
       </div>
       <div v-else flex items-center>
         <span flex items-center>
-          <em mr-2 inline-block h-5 w-5 border border-base rounded hover="cursor-pointer" :style="{ backgroundColor: color }" @click="showHex = !showHex" />
+          <em mr-2 inline-block h-5 w-5 border border-base rounded hover="cursor-pointer border-primary" :style="{ backgroundColor: color }" @click="showHex = !showHex" />
           :
           <span hover="underline underline-offset-3 cursor-pointer" @click="copy(color)">{{ color }}</span>
         </span>

--- a/src/client/pages/__eyedropper.vue
+++ b/src/client/pages/__eyedropper.vue
@@ -4,7 +4,18 @@ import { useDevtoolsClient } from '../logic/client'
 const client = useDevtoolsClient()
 const frameState = useFrameState()
 const router = useRouter()
-const color = ref('')
+const hexColor = ref('')
+const showHex = ref(true)
+const color = computed(() => showHex.value ? hexColor.value : hexToRgb(hexColor.value))
+const copy = useCopy()
+
+function getDecimal(hex: string, start: number, end: number) {
+  return Number.parseInt(hex.slice(start, end), 16)
+}
+
+function hexToRgb(hex: string) {
+  return hex ? `rgb(${getDecimal(hex, 1, 3)},${getDecimal(hex, 3, 5)},${getDecimal(hex, 5, 7)})` : ''
+}
 
 useEventListener('keydown', (e) => {
   if (e.key === 'Escape')
@@ -30,15 +41,15 @@ async function open() {
 }
 
 async function restart() {
-  color.value = ''
+  hexColor.value = ''
   open().then((res) => {
-    color.value = res.sRGBHex
+    hexColor.value = res.sRGBHex
   })
 }
 
 onMounted(() => {
   open().then((res) => {
-    color.value = res.sRGBHex
+    hexColor.value = res.sRGBHex
   })
 })
 
@@ -72,9 +83,9 @@ function ErrorBoundary() {
       </div>
       <div v-else flex items-center>
         <span flex items-center>
-          <em mr-2 inline-block h-5 w-5 border border-base rounded :style="{ backgroundColor: color }" />
+          <em mr-2 inline-block h-5 w-5 border border-base rounded hover="cursor-pointer" :style="{ backgroundColor: color }" @click="showHex = !showHex" />
           :
-          {{ color }}
+          <span hover="underline underline-offset-3 cursor-pointer" @click="copy(color)">{{ color }}</span>
         </span>
         <span ml-2 flex cursor-pointer items-center border border-base rounded-10 p-2 hover="bg-active" @click="restart">
           <i class="i-mdi:eyedropper" text-3 />


### PR DESCRIPTION
![image](https://github.com/webfansplz/vite-plugin-vue-devtools/assets/31237954/ab3e3dcb-796d-4e78-96a6-2f2a2e7b66c6)