### PR TITLE
feat: hide devtools panel during print media

### DIFF
--- a/src/node/views/Main.vue
+++ b/src/node/views/Main.vue
@@ -407,4 +407,10 @@ collectHookBuffer()
     opacity: 0.2;
   }
 }
+
+@media print {
+  #vue-devtools-anchor {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
Maybe we should hide the devtool while print.