### PR TITLE
fix(client): hide scrollbar in Firefox

### DIFF
--- a/packages/client/styles/main.css
+++ b/packages/client/styles/main.css
@@ -147,6 +147,11 @@ textarea {
   background: #8886;
 }
 
+.no-scrollbar {
+  /* Support Firefox */
+  scrollbar-width: none
+}
+
 .no-scrollbar::-webkit-scrollbar {
   display: none;
   width: 0 !important;


### PR DESCRIPTION
由于Firefox不支持 `-webkit-scrollbar` 属性，所以在 .no-scrollbar 中使用 `scrollbar-width` 属性解决滚动条。

修改前：

![截屏2023-07-21 20 44 18](https://github.com/webfansplz/vite-plugin-vue-devtools/assets/3993028/0c1f345e-e024-40c4-9850-fe6246d9c8b9)

修改后：

![截屏2023-07-21 20 44 45](https://github.com/webfansplz/vite-plugin-vue-devtools/assets/3993028/841c601e-8119-48ae-88ed-6b77f65c5e06)
