### PR TITLE
fix(eyedropper): show feedback in error boundary

### DIFF
--- a/packages/client/pages/__eyedropper.vue
+++ b/packages/client/pages/__eyedropper.vue
@@ -34,7 +34,7 @@ const isSupported = inSecurityContext && supportEyeDropper
 
 async function open() {
   if (!isSupported)
-    return
+    return {}
   // @ts-expect-error missing types?
   const eyeDropper = new EyeDropper()
   return eyeDropper.open()


### PR DESCRIPTION
``` javascript
open().then((res) => {
    hexColor.value = res.sRGBHex
  }).catch(() => {
    close()
  })
```

在调用open时候，遇到不支持的浏览器时，open方法会返回`undefined`，导致上面的`res.sRGBHex`报错，并被catch语句捕获，运行close方法，这样就无法显示feedback信息。解决方法是，让open返回一个空对象，这样在then中就不会发生错误。