### PR TITLE
Fix/fullsreen mode

### DIFF
--- a/packages/client/components/FullscreenButton.vue
+++ b/packages/client/components/FullscreenButton.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { useDevToolsClient } from '../logic/client'
 
-const isFullscreen = ref(false)
+const { viewMode } = useFrameState()
 const client = useDevToolsClient()
-
+const isFullscreen = computed(() => viewMode.value === 'fullscreen')
 function toggleFullscreen() {
   client.value.panel?.toggleViewMode(isFullscreen.value ? 'default' : 'fullscreen')
-  isFullscreen.value = !isFullscreen.value
 }
 </script>
 

--- a/packages/client/composables/state.ts
+++ b/packages/client/composables/state.ts
@@ -12,6 +12,7 @@ export interface DevToolsFrameState {
   isFirstVisit: boolean
   closeOnOutsideClick: boolean
   minimizePanelInactive: number
+  viewMode: ViewMode
 }
 
 const frameState = useLocalStorage<DevToolsFrameState>(FRAME_STATE_STORAGE_KEY, {
@@ -25,6 +26,7 @@ const frameState = useLocalStorage<DevToolsFrameState>(FRAME_STATE_STORAGE_KEY, 
   isFirstVisit: true,
   closeOnOutsideClick: false,
   minimizePanelInactive: 5000,
+  viewMode: 'default',
 }, { mergeDefaults: true })
 
 const frameStateRefs = toRefs(frameState)

--- a/packages/node/src/views/FrameBox.vue
+++ b/packages/node/src/views/FrameBox.vue
@@ -61,9 +61,7 @@ useWindowEventListener('mousedown', (e: MouseEvent) => {
 })
 
 useWindowEventListener('mousemove', (e) => {
-  if (!isResizing.value)
-    return
-  if (!state.value.open)
+  if (!isResizing.value || !state.value.open)
     return
 
   const iframe = props.client.getIFrame()
@@ -118,49 +116,49 @@ const viewModeClass = computed(() => {
   >
     <!-- Handlers -->
     <div
-      v-show="state.position !== 'top'"
+      v-show="state.position !== 'top' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-horizontal"
       :style="{ top: 0 }"
       @mousedown.prevent="() => isResizing = { top: true }"
     />
     <div
-      v-show="state.position !== 'bottom'"
+      v-show="state.position !== 'bottom' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-horizontal"
       :style="{ bottom: 0 }"
       @mousedown.prevent="() => isResizing = { bottom: true }"
     />
     <div
-      v-show="state.position !== 'left'"
+      v-show="state.position !== 'left' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-vertical"
       :style="{ left: 0 }"
       @mousedown.prevent="() => isResizing = { left: true }"
     />
     <div
-      v-show="state.position !== 'right'"
+      v-show="state.position !== 'right' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-vertical"
       :style="{ right: 0 }"
       @mousedown.prevent="() => isResizing = { right: true }"
     />
     <div
-      v-show="state.position !== 'top' && state.position !== 'left'"
+      v-show="state.position !== 'top' && state.position !== 'left' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-corner"
       :style="{ top: 0, left: 0, cursor: 'nwse-resize' }"
       @mousedown.prevent="() => isResizing = { top: true, left: true }"
     />
     <div
-      v-show="state.position !== 'top' && state.position !== 'right'"
+      v-show="state.position !== 'top' && state.position !== 'right' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-corner"
       :style="{ top: 0, right: 0, cursor: 'nesw-resize' }"
       @mousedown.prevent="() => isResizing = { top: true, right: true }"
     />
     <div
-      v-show="state.position !== 'bottom' && state.position !== 'left'"
+      v-show="state.position !== 'bottom' && state.position !== 'left' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-corner"
       :style="{ bottom: 0, left: 0, cursor: 'nesw-resize' }"
       @mousedown.prevent="() => isResizing = { bottom: true, left: true }"
     />
     <div
-      v-show="state.position !== 'bottom' && state.position !== 'right'"
+      v-show="state.position !== 'bottom' && state.position !== 'right' && props.viewMode === 'default'"
       class="vue-devtools-resize-handle vue-devtools-resize-handle-corner"
       :style="{ bottom: 0, right: 0, cursor: 'nwse-resize' }"
       @mousedown.prevent="() => isResizing = { bottom: true, right: true }"

--- a/packages/node/src/views/FrameBox.vue
+++ b/packages/node/src/views/FrameBox.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
       disable: () => void
     } | undefined
   }
-  viewMode: 'xs' | 'default' | 'fullscreen'
+  viewMode: ViewMode
 }>()
 
 const container = ref<HTMLElement>()

--- a/packages/node/src/views/Main.vue
+++ b/packages/node/src/views/Main.vue
@@ -295,7 +295,6 @@ collectHookBuffer()
 }
 #vue-devtools-anchor.fullscreen {
   transform: none !important;
-  left: 0 !important;
 }
 
 #vue-devtools-anchor .vue-devtools-icon-button {

--- a/packages/node/src/views/Main.vue
+++ b/packages/node/src/views/Main.vue
@@ -6,7 +6,7 @@ import vueDevToolsOptions from 'virtual:vue-devtools-options'
 import { DevToolsHooks, collectDevToolsHookBuffer } from '@vite-plugin-vue-devtools/core'
 import Frame from './FrameBox.vue'
 import ComponentInspector from './ComponentInspector.vue'
-import { useHighlightComponent, useIframe, useInspector, usePanelVisible, usePiPMode, usePosition, useRerenderHighlight } from './composables'
+import { useHighlightComponent, useIframe, useInspector, usePanelState, usePanelVisible, usePiPMode, usePosition, useRerenderHighlight } from './composables'
 import { checkIsSafari, useColorScheme, usePreferredColorScheme, warn } from './utils'
 import RerenderIndicator from './RerenderIndicator.vue'
 
@@ -22,15 +22,11 @@ const hook = props.hook
 const { hookBuffer, collect } = collectDevToolsHookBuffer()
 
 let isAppCreated = false
-const panelState = ref<{
-  viewMode: ViewMode
-}>({
-  viewMode: 'default',
-})
 
 const { togglePanelVisible, closePanel, panelVisible } = usePanelVisible()
 const panelEl = ref<HTMLDivElement>()
 const { onPointerDown, bringUp, anchorStyle, iframeStyle, isDragging, isVertical, isHidden, panelStyle } = usePosition(panelEl)
+const { viewMode, toggleViewMode } = usePanelState()
 const vars = computed(() => {
   const colorScheme = useColorScheme()
   const dark = colorScheme.value === 'auto'
@@ -91,9 +87,7 @@ async function setupClient(iframe: HTMLIFrameElement) {
     hook,
     hookBuffer,
     panel: {
-      toggleViewMode: (mode?: ViewMode) => {
-        panelState.value.viewMode = mode ?? 'default'
-      },
+      toggleViewMode,
       toggle: togglePanelVisible,
       popup,
     },
@@ -237,7 +231,7 @@ collectHookBuffer()
     :class="{
       'vue-devtools-vertical': isVertical,
       'vue-devtools-hide': isHidden,
-      'fullscreen': panelState.viewMode === 'fullscreen',
+      'fullscreen': viewMode === 'fullscreen',
     }"
     @mousemove="bringUp"
   >
@@ -284,7 +278,7 @@ collectHookBuffer()
         },
         getIFrame: getIframe,
       }"
-      :view-mode="panelState.viewMode"
+      :view-mode="viewMode"
     />
   </div>
   <!-- component inspector -->

--- a/packages/node/src/views/composables.ts
+++ b/packages/node/src/views/composables.ts
@@ -14,6 +14,7 @@ interface DevToolsFrameState {
   isFirstVisit: boolean
   closeOnOutsideClick: boolean
   minimizePanelInactive: number
+  viewMode: ViewMode
 }
 
 interface ComponentInspectorBounds {
@@ -41,6 +42,7 @@ export const state = useObjectStorage<DevToolsFrameState>('__vue-devtools-frame-
   isFirstVisit: true,
   closeOnOutsideClick: false,
   minimizePanelInactive: 5000,
+  viewMode: 'default',
 })
 
 // ---- useIframe ----
@@ -499,6 +501,29 @@ export function usePosition(panelEl: Ref<HTMLElement | undefined>) {
     onPointerDown,
     bringUp,
   }
+}
+
+// ---- usePanelState ----
+export function usePanelState() {
+  const viewMode = computed({
+    get() {
+      return state.value.viewMode
+    },
+    set(value) {
+      state.value.viewMode = value
+    },
+  })
+  let perViewMode = viewMode.value
+
+  function toggleViewMode(mode: ViewMode) {
+    const newMode = mode ?? perViewMode
+    setTimeout(() => {
+      perViewMode = viewMode.value
+      viewMode.value = newMode
+    }, 0)
+  }
+
+  return { viewMode, toggleViewMode }
 }
 
 // ---- useHighlightComponent ----


### PR DESCRIPTION
- [X] invalid "Exit Fullscreen" button
> 点击"Fullscreen"按钮后，popper隐藏后的5秒钟后再打开Popper，理应是"Exit Fullscreen"的按钮，结果被初始化为"Fullscreen"，所以在frame-state里保存了viewMode这个状态。

- [X] disabled resize in non "default" view mode
> 在viewMode是非"default"的情况下，panel是可以继续调整大小的（虽然看起来没有变化），一旦调整后恢复为"default"，则panel的会变成错误的大小

- [X] set correct anchor position in fullscreen
> 在全屏状态下，使用快捷键隐藏panel后，anchor移动到屏幕左下角，且无法改变位置。