### PR TITLE
fix: resolve type from ui kit

### DIFF
--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -17,7 +17,10 @@
       "vite-plugin-vue-devtools/client"
     ],
     "paths": {
-      "~/*": ["./*"]
+      "~/*": ["./*"],
+      "@vite-plugin-vue-devtools/ui-kit/components/*": [
+        "./node_modules/@vite-plugin-vue-devtools/ui-kit/dist/components/*"
+      ]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
- resolved #230 
  - I found that adding the paths alias to `tsconfig.json` resolves the types in `ui-kit` correctly.