### PR TITLE
fix: hide component inspector overlay when bounds is incomplete

### DIFF
--- a/packages/node/src/views/ComponentInspector.vue
+++ b/packages/node/src/views/ComponentInspector.vue
@@ -24,7 +24,7 @@ const inspectorCardStyle = computed(() => ({ top: props.bounds.top < 35 ? 0 : '-
 </script>
 
 <template>
-  <div class="vue-devtools-component-inspector" :style="inspectorStyle">
+  <div v-show="bounds.width || bounds.height" class="vue-devtools-component-inspector" :style="inspectorStyle">
     <span class="vue-devtools-component-inspector-card" :style="inspectorCardStyle">
       &lt;{{ name }}&gt;
       <i>{{ Math.round(bounds.width * 100) / 100 }} x {{ Math.round(bounds.height * 100) / 100 }}</i>

--- a/packages/node/src/views/Main.vue
+++ b/packages/node/src/views/Main.vue
@@ -288,7 +288,7 @@ collectHookBuffer()
     />
   </div>
   <!-- component inspector -->
-  <ComponentInspector v-if="overlayVisible" :bounds="bounds" :name="componentName" />
+  <ComponentInspector v-if="overlayVisible && bounds" :bounds="bounds" :name="componentName" />
   <RerenderIndicator />
 </template>
 


### PR DESCRIPTION
Closes #237 